### PR TITLE
Remove papertrail pytest11 entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,6 @@ show_missing = true
 skip_covered = true
 fail_under = 95
 
-[project.entry-points.pytest11]
-papertrail = "papertrail.__main__"
-
 [tool.pytest]
 # addopts = ["--codspeed"]
 


### PR DESCRIPTION
Fixes #34

## Summary

- Remove the `[project.entry-points.pytest11]` section from `pyproject.toml`
- This entrypoint registers `papertrail.__main__` as a pytest plugin for **all** danom consumers, but `papertrail` is not a dependency of danom — only a dev dependency
- Every project that depends on danom currently needs `-p no:papertrail` to avoid `ModuleNotFoundError: No module named 'papertrail'`
- The papertrail package itself already [commented out this entrypoint](https://github.com/second-ed/papertrail/blob/dev/pyproject.toml#L32-L33) in its own `pyproject.toml`